### PR TITLE
proposal for menu label enum usage

### DIFF
--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -35,7 +35,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -78,6 +77,7 @@ import javax.swing.event.ChangeListener;
 import net.sf.jabref.*;
 import net.sf.jabref.gui.actions.*;
 import net.sf.jabref.gui.keyboard.KeyBinds;
+import net.sf.jabref.gui.labels.MenuLabel;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.gui.worker.MarkEntriesAction;
 import net.sf.jabref.gui.preftabs.PreferencesDialog;
@@ -209,15 +209,20 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction newSubDatabaseAction = new NewSubDatabaseAction(this);
     private final AbstractAction integrityCheckAction = new IntegrityCheckAction(this);
     private final AbstractAction forkMeOnGitHubAction = new ForkMeOnGitHubAction();
-    private final AbstractAction help = new HelpAction("JabRef help", helpDiag,
-            GUIGlobals.baseFrameHelp, Localization.lang("JabRef help"),
-            prefs.getKey("Help"));
-    private final AbstractAction contents = new HelpAction("Help contents", helpDiag,
-            GUIGlobals.helpContents, Localization.lang("Help contents"),
-            IconTheme.getImage("helpContents"));
-    private final AbstractAction about = new HelpAction("About JabRef", helpDiag,
-            GUIGlobals.aboutPage, Localization.lang("About JabRef"),
-            IconTheme.getImage("about"));
+
+//    private final AbstractAction help = new HelpAction("JabRef help", helpDiag,
+//            GUIGlobals.baseFrameHelp, Localization.lang("JabRef help"),
+//            prefs.getKey("Help"));
+////    private final AbstractAction contents = new HelpAction("Help contents", helpDiag,
+//            GUIGlobals.helpContents, Localization.lang("Help contents"),
+//            IconTheme.getImage("helpContents"));
+//    private final AbstractAction about = new HelpAction("About JabRef", helpDiag,
+//            GUIGlobals.aboutPage, Localization.lang("About JabRef"),
+//            IconTheme.getImage("about"));
+    private final AbstractAction help = new HelpAction(MenuLabel.JabRef_Help, helpDiag, GUIGlobals.baseFrameHelp);
+    private final AbstractAction contents = new HelpAction(MenuLabel.Help_Contents, helpDiag, GUIGlobals.helpContents);
+    private final AbstractAction about = new HelpAction(MenuLabel.About_JabRef, helpDiag, GUIGlobals.aboutPage);
+
     private final AbstractAction editEntry = new GeneralAction(Actions.EDIT, "Edit entry",
             Localization.lang("Edit entry"),
             prefs.getKey(KeyBinds.EDIT_ENTRY),

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.help;
 
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
-import java.net.URL;
 
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -26,6 +25,7 @@ import javax.swing.KeyStroke;
 
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.MnemonicAwareAction;
+import net.sf.jabref.gui.labels.MenuLabel;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -86,6 +86,19 @@ public class HelpAction extends MnemonicAwareAction {
         putValue(Action.NAME, title);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         this.diag = diag;
+        this.helpFile = helpFile;
+    }
+
+    public HelpAction(MenuLabel menuLabel, HelpDialog dialog, String helpFile) {
+        putValue(Action.NAME, menuLabel.getTitleKey());
+        putValue(Action.SMALL_ICON, menuLabel.getIcon().orElse(IconTheme.getImage("help")));
+        if(menuLabel.getDescriptionKey().isPresent()) {
+            putValue(Action.SHORT_DESCRIPTION, Localization.lang(menuLabel.getDescriptionKey().get()));
+        }
+        if(menuLabel.getKeyStroke().isPresent()) {
+            putValue(Action.ACCELERATOR_KEY, menuLabel.getKeyStroke().get());
+        }
+        this.diag = dialog;
         this.helpFile = helpFile;
     }
 

--- a/src/main/java/net/sf/jabref/gui/labels/MenuLabel.java
+++ b/src/main/java/net/sf/jabref/gui/labels/MenuLabel.java
@@ -1,0 +1,63 @@
+package net.sf.jabref.gui.labels;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.gui.keyboard.KeyBinds;
+import net.sf.jabref.logic.l10n.Localization;
+
+import javax.swing.*;
+import java.util.Optional;
+
+public enum MenuLabel {
+
+    Abbreviate_journal_names_ISO("Abbreviate_journal_names_(ISO)"),
+    Abbreviate_journal_names_MEDLINE("Abbreviate_journal_names_(MEDLINE)"),
+    About_JabRef("About_JabRef", "About JabRef", "about"),
+    Append_database("Append_database"),
+
+    Help_Contents("Help_contents", "Help_contents", "helpContents"),
+    JabRef_Help("JabRef help", "JabRef help", "help", KeyBinds.HELP);
+
+    private String titleKey;
+    private Optional<String> descriptionKey = Optional.empty();
+    private Optional<ImageIcon> icon = Optional.empty();
+    private Optional<KeyStroke> keyStroke = Optional.empty();
+
+    MenuLabel(String titleKey) {
+        this.titleKey = Localization.menuTitle(titleKey);
+    }
+
+    MenuLabel(String titleKey, String descriptionKey) {
+        this.titleKey = Localization.menuTitle(titleKey);
+        this.descriptionKey = Optional.of(Localization.lang(descriptionKey));
+    }
+
+    MenuLabel(String titleKey, String descriptionKey, String iconName) {
+        this.titleKey = Localization.menuTitle(titleKey);
+        this.descriptionKey = Optional.of(Localization.lang(descriptionKey));
+        this.icon = Optional.of(IconTheme.getImage(iconName));
+    }
+
+    MenuLabel(String titleKey, String descriptionKey, String iconName, String keyStroke) {
+        this.titleKey = Localization.menuTitle(titleKey);
+        this.descriptionKey = Optional.of(Localization.lang(descriptionKey));
+        this.icon = Optional.of(IconTheme.getImage(iconName));
+        this.keyStroke = Optional.of(Globals.prefs.getKey(keyStroke));
+    }
+
+    public String getTitleKey() {
+        return titleKey;
+    }
+
+    public Optional<String> getDescriptionKey() {
+        return descriptionKey;
+    }
+
+    public Optional<ImageIcon> getIcon() {
+        return icon;
+    }
+
+    public Optional<KeyStroke> getKeyStroke() {
+        return keyStroke;
+    }
+}


### PR DESCRIPTION
Quick implementation for possible enum usage to define "Menu Labels"

Some aspects:
- Title, short description (for tooltips), icons and keyStrokes integrated
- tested using HelpActions - Help menu is changed to enum

Todo:
- implement unit testing of all defined enums: Check whether title, description, icon and keystroke can be resolved (for default locale)
- Tooling to determine which menuTitles/JabRef keys are missing/obsolete in the language specific properties files (Replace python script?)
